### PR TITLE
Fixing title attribute in Gitbook

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,4 +1,5 @@
 {
+  "title": "Authoring Content for DataCamp",
   "plugins": [
     "bootstrap-callout",
     "expandable-chapters",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Welcome!
+# Welcome
 
 This documentation is the single source of truth for all things related to creating training content on the DataCamp platform. Anyone can create content for free using our authoring tools, then make that content available to others.
 


### PR DESCRIPTION
The `title` attribute in `book.json` is working properly. I also removed an exclamation mark from a chapter title because I'm finicky that way.