### PR TITLE
Refining discussion of personas based on feedback from instructors.

### DIFF
--- a/docs/courses/design/personas.md
+++ b/docs/courses/design/personas.md
@@ -7,6 +7,14 @@ instructors should explain how it will or won't help these people,
 and what extra skills or prerequisite knowledge they are assuming their students have
 above and beyond what's included in the persona.
 
+Note: these personas mention some specific technologies or domains,
+such as Python or epidemiology.
+When using these personas,
+replace these by equivalent levels of knowledge about technologies or domains appropriate to your course,
+e.g.,
+novice understanding of R but advanced understanding of medical imaging
+(or vice versa).
+
 ## Advanced Alex
 
 - Age: 34


### PR DESCRIPTION
A couple of instructors have been confused by the fact that our personas mention specific technologies and domains that aren't relevant to what they're teaching; the addition makes it clear that they should assume equivalent understanding of what's relevant to their course.