### PR TITLE
Dividing intermediate personas in three

### DIFF
--- a/docs/courses/design/choose-learner-personas.md
+++ b/docs/courses/design/choose-learner-personas.md
@@ -1,15 +1,25 @@
 # Step 2 - Who Is This Course for?
 
-Read the page of [sample learner personas](/courses/design/personas.html) and choose 1 or 2 of them as the most likely to benefit from your course. Write a sentence about the ones you chose stating how good a fit you think they might be.
+Read the page of [sample learner personas](/courses/design/personas.html) and choose 1 or 2 of them as the most likely to benefit from your course. Write a sentence about the ones you chose stating how good a fit you think they might be.  In brief, the five personas are:
 
+- Unaware Umberto: is new to statistics, programming, and the domain he's working in.
+- Starting Sindhu: has domain expertise, but not as much programming or statistics.
+- Coder Chen: is a strong programmer, but lacks domain expertise and statistical background.
+- Mathematical Marta: strong mathematical and statistical background, a little programming, completely new to the domain.
+- Advanced Alex: has all three kinds of knowledge.
+
+Note: the [full description of these personas](/courses/design/personas.html) mention specific technologies or domains,
+such as Python or epidemiology.
+When using these personas,
+replace these by equivalent levels of knowledge about technologies or domains appropriate to your course,
+e.g.,
+novice understanding of R but advanced understanding of medical imaging.
 
 ## Examples
 
-From a course on RNA-Seq analysis. After discussion with the Curriculum Lead, it was decided that the target audiences didn't exactly fit the sample personas, and that the trick to the course was balancing students with biology knowledge that wanted to learn R, and students who knew R but wanted to learn the biological application. 
+1. The author of an introductory course on data visualization with Python chose Marta, Sindhu, and Umberto as her audience.  Her reasoning is that Chen and Alex (who are both strong programmers) will be able to pick up the programming on their own without a course, but the other three all need a course to show them how code can create pictures.
 
-- Biologist. He/She works in a biology lab and generates data. Very little knowledge about R, it is the hard part.
-- Statistician with no prior knowledge about biology/scRNA-seq. He/She knows basic R.
-
+2. The author of a course on RNA-Seq analysis decided that her target audience included people who know biology but are lacking R and/or statistics.  She therefore picked Sindhu as the main learner persona for her course, and Alex as an additional persona.
 
 ## FAQs
 
@@ -19,8 +29,7 @@ You can comment on how good a fit the other personas would be for your course, b
 
 ### Can I invent my own personas?
 
-Yes! If you have a specific target audience in mind for your course, feel free to describe them in this step. You can discuss the new persona with your Curriculum Lead to decide whether or not it constitutes a realistic DataCamp student. 
-
+If necessary, but please discuss with your Curriculum Lead first to decide whether or not it constitutes a realistic DataCamp student.
 
 ## Good ideas
 

--- a/docs/courses/design/personas.md
+++ b/docs/courses/design/personas.md
@@ -15,60 +15,51 @@ e.g.,
 novice understanding of R but advanced understanding of medical imaging
 (or vice versa).
 
-## Advanced Alex
+## Unaware Umberto
 
-- Age: 34
-- Location: Reno, Nevada, USA
-- Education: Bachelor in Mathematics and Master in Finance & Risk Management - University of Nevada
-- Personal: Interested in teaching courses himself some day.
+- Age: 27
+- Location: London, UK
+- Education: Bachelor in Philosophy & Bachelor in Business  Economics - King's College London
+- Personal: Partially deaf, so prefers materials with closed captioning.
 
-**Previous Jobs**
+**Previous Job**
 
-- Pricing analyst for power distributor.
-- Financial analyst at Bank of America.
+- Financial advisor at Lloyds Banking Group.
 
 **Current Job**
 
-- Head quantitative analyst in small hedge fund.
-
-**Career Goal**
-
-After developing his skill set and finding out what he likes in
-previous jobs, Alex is set on staying in this role for quite a
-while. He was recently made part of the management team. His main
-concern is driving the company forward and outpacing competitors.
+- Financial analyst at KPMG.
 
 **Data Science Education Experience**
 
-Having touched the basics of data science in his education, Alex is
-currently using Python in his job. To get better and improve his
-business' competitive edge, he went looking for more Python skills.
-Google and forums led him to try edX and DataCamp. DataCamp's renowned
-instructors and the fact that respected institutions use it pulled
-Alex in. Today, he uses DataCamp as his first foundational resource
-and supplements it with specific, more in depth courses on Coursera.
+Having only worked with excel and some SPSS in his studies, Umberto
+learned most of the modelling and analysis techniques on the job. The
+managers he worked with so far in his projects used Excel and custom
+KPMG tools, and he hasn't been in touch with data science tools as of
+now.  He thus doesn't know about them or how they could help him yet.
+However, Umberto is constantly looking for easier and more efficient
+ways of doing his job tasks-at-hand to move up in his demanding
+career.
 
 **DataCamp Experience**
 
-The main draw for Alex is that DataCamp brings him high-level
-understanding of what's out there in the data science field, on pace
-with the new developments. He doesn't mind shopping around for more
-specific and in-depth content, but could see this becoming a bit
-annoying in the future. In any case, the business value of DataCamp
-for him lies in the apply fast way the learning experience is set up.
+Umberto doesn't know DataCamp. 
 
-> From a business perspective, I need to be able to apply the data
-> science I learn straight away - I can't afford to first spend 3
-> months learning without being able to apply.
+**Career Goal**
+
+Having a not-so-common education background, Umberto is set on
+learning as much as possible working in consultancy for many different
+clients. He loves the on the job trainings and wants to build
+knowledge so he can grow into a project lead role. In the future, he
+sees himself as lead analyst for a food import/export company.
+
+> Building analytical reasonings and spreadsheet models from scratch
+> is what I like and spend most of my time at work doing.
 
 **Is Uncertain About…**
      
-- Such a fast moving field
-  (focusing on the right data science subjects).
-- So many views and approaches
-  (having the right take on certain topics)
-- Getting data science to really work for him
-  (how to apply and build business value).
+- Doing things correctly and efficiently.
+- Growing as fast as his colleagues.
 
 ## Starting Sindhu
 
@@ -83,27 +74,27 @@ for him lies in the apply fast way the learning experience is set up.
 
 **Current Job**
 
-- Scientist at Merck & Co pharmaceuticals.
+- Scientist at a pharmaceuticals company.
 
 **Career Goal**
 
 Sindhu works in a team of scientists researching the effectiveness of
-vaccines. She invests a lot of time in clearly presenting and
-reporting her results to their superiors. She is constantly looking
-for better ways of doing so and hopes to one day become the principal
-scientist on her team this way.
+vaccines. She invests a lot of time in the lab, and in summarizing and
+reporting her results to her superiors. She is constantly looking for
+better ways of doing so and hopes to one day become the principal
+scientist on her team.
 
 **Data Science Education Experience**
 
-SIndhu came out of university with knowledge about the most important
-statistical concepts and techniques. However, needing to visualise a
-lot of her findings, Sindhu quickly found that nor Excel and JMP - the
-tools used in her team - nor SPSS - the software used in university -
-were as customizable as she would have liked. Moreover, she lost a lot
-of time building her model from scratch each time.  A quick survey
-among research scientist friends led her to R and DataCamp.  After two
-free courses and the relief that it was actually doable, Sindhu
-subscribed.
+SIndhu came out of university with expert-level knowledge of
+immunology, but only knows basic statistical concepts and
+techniques. However, needing to visualise a lot of her findings,
+Sindhu quickly found that nor Excel and JMP - the tools used in her
+team - nor SPSS - the software used in university - were as
+customizable as she would have liked. Moreover, she lost a lot of time
+building her model from scratch each time.  A quick survey among
+research scientist friends led her to R and DataCamp.  After two free
+courses and the relief that it was actually doable, Sindhu subscribed.
 
 **DataCamp Experience**
 
@@ -181,48 +172,113 @@ her tinker with code as she went along.
 - Whether she has the necessary mathematics background
   (and whether she can fill in the gaps in the time she can afford to invest).
 
-## Unaware Umberto
+## Mathematical Marta
 
-- Age: 27
-- Location: London, UK
-- Education: Bachelor in Philosophy & Bachelor in Business  Economics - King's College London
-- Personal: Partially deaf, so prefers materials with closed captioning.
+- Age: 28
+- Location: Prague, Czech Republic
+- Education: PhD in Mathematics - Charles University
+- Personal: Retraining after deciding not to pursue an academic career.
 
-**Previous Job**
+**Previous Jobs**
 
-- Financial advisor at Lloyds Banking Group.
+- PhD student in pure mathematics.
+- Two summer research jobs (both doing pure math).
+- One-year post-doctoral position (also in pure math).
 
 **Current Job**
 
-- Financial analyst at KPMG.
-
-**Data Science Education Experience**
-
-Having only worked with excel and some SPSS in his studies, Umberto
-learned most of the modelling and analysis techniques on the job. The
-managers he worked with so far in his projects used Excel and custom
-KPMG tools, and he hasn't been in touch with data science tools as of
-now.  He thus doesn't know about them or how they could help him yet.
-However, Umberto is constantly looking for easier and more efficient
-ways of doing his job tasks-at-hand to move up in his demanding
-career.
-
-**DataCamp Experience**
-
-Umberto doesn't know DataCamp. 
+- Unemployed.
 
 **Career Goal**
 
-Having a not-so-common education background, Umberto is set on
-learning as much as possible working in consultancy for many different
-clients. He loves the on the job trainings and wants to build
-knowledge so he can grow into a project lead role. In the future, he
-sees himself as lead analyst for a food import/export company.
+Marta recently completed a post-doc in non-homotopic knot theory,
+having done her PhD in the same subject.  She has decided that she
+doesn't want to pursue an academic career, and wants to retrain as a
+data scientist: several of her friends from theoretical physics have
+already done so, and she thinks what they're doing is both interesting
+and useful. However, she hasn't done statistics since she was an
+undergraduate, and knows next to nothing about finance, logistics,
+marketing, and other domains where data science is used.
 
-> Building analytical reasonings and spreadsheet models from scratch
-> is what I like and spend most of my time at work doing.
+**Data Science Education Experience**
+
+Marta is very comfortable with mathematical abstractions, and is able
+to make sense of abstruse theory quickly and easily, but even the one
+stats course she did eight years ago was theoretically oriented.  She
+is aware that real-world data is sometimes messy, but hasn't had to
+deal with that messiness herself.
+
+**DataCamp Experience**
+
+Marta was originally worried that her lack of real-world experience
+would make it hard for her to understand the examples in DataCamp
+courses.  She has found that is occasionally the case, but has usually
+been able to fill in the gaps in her knowledge by browsing Wikipedia.
+She sometimes wishes that DataCamp courses spent more time on the
+mathematical underpinnings of the methods being used - she is
+accustomed to proofs, proofs, and more proofs - but has been
+pleasantly surprised to find how much she enjoys programming.
+
+> I started this because I wanted to do the kind of work my friends
+> are doing.  I'm continuing with it because I find it just as
+> challenging as the theory I used to do.
 
 **Is Uncertain About…**
      
-- Doing things correctly and efficiently.
-- Growing as fast as his colleagues.
+- Whether she can catch up with people who have been programming for
+  years.
+
+## Advanced Alex
+
+- Age: 34
+- Location: Reno, Nevada, USA
+- Education: Bachelor in Mathematics and Master in Finance & Risk Management - University of Nevada
+- Personal: Interested in teaching courses himself some day.
+
+**Previous Jobs**
+
+- Pricing analyst for power distributor.
+- Financial analyst at Bank of America.
+
+**Current Job**
+
+- Head quantitative analyst in small hedge fund.
+
+**Career Goal**
+
+After developing his skill set and finding out what he likes in
+previous jobs, Alex is set on staying in this role for quite a
+while. He was recently made part of the management team. His main
+concern is driving the company forward and outpacing competitors.
+
+**Data Science Education Experience**
+
+Having touched the basics of data science in his education, Alex is
+currently using Python in his job. To get better and improve his
+business' competitive edge, he went looking for more Python skills.
+Google and forums led him to try edX and DataCamp. DataCamp's renowned
+instructors and the fact that respected institutions use it pulled
+Alex in. Today, he uses DataCamp as his first foundational resource
+and supplements it with specific, more in depth courses on Coursera.
+
+**DataCamp Experience**
+
+The main draw for Alex is that DataCamp brings him high-level
+understanding of what's out there in the data science field, on pace
+with the new developments. He doesn't mind shopping around for more
+specific and in-depth content, but could see this becoming a bit
+annoying in the future. In any case, the business value of DataCamp
+for him lies in the apply fast way the learning experience is set up.
+
+> From a business perspective, I need to be able to apply the data
+> science I learn straight away - I can't afford to first spend 3
+> months learning without being able to apply.
+
+**Is Uncertain About…**
+     
+- Such a fast moving field
+  (focusing on the right data science subjects).
+- So many views and approaches
+  (having the right take on certain topics)
+- Getting data science to really work for him
+  (how to apply and build business value).

--- a/docs/courses/design/personas.md
+++ b/docs/courses/design/personas.md
@@ -34,7 +34,7 @@ novice understanding of R but advanced understanding of medical imaging
 
 Umberto's degree gave him an excellent grounding in economic theory,
 but the only quantitative work he did was with very small data sets
-using Excel and a little bit of copy-and-pase SPSS.  The managers he
+using Excel and a little bit of copy-and-paste SPSS.  The managers he
 worked with so far in his projects used more complex spreadsheets and
 some software packages developed in house; he hasn't yet had much
 exposure to R, Python, SQL, or other stars in the data science
@@ -49,9 +49,9 @@ Umberto doesn't know DataCamp.
 
 **Career Goal**
 
-Aware that his background hasn't given him the samel quantitative
+Aware that his background hasn't given him the same quantitative
 skills as many of his peers, Umberto is set on learning as much as
-possible as quickly as he can. He loves the on the job trainings and
+possible as quickly as he can. He loves the on-the-job trainings and
 wants to build knowledge so he can grow into a project lead role.
 
 > Building analytical reasonings and spreadsheet models from scratch

--- a/docs/courses/design/personas.md
+++ b/docs/courses/design/personas.md
@@ -17,9 +17,9 @@ novice understanding of R but advanced understanding of medical imaging
 
 ## Unaware Umberto
 
-- Age: 27
+- Age: 25
 - Location: London, UK
-- Education: Bachelor in Philosophy & Bachelor in Business  Economics - King's College London
+- Education: Bachelor in Economic History - King's College London
 - Personal: Partially deaf, so prefers materials with closed captioning.
 
 **Previous Job**
@@ -28,15 +28,17 @@ novice understanding of R but advanced understanding of medical imaging
 
 **Current Job**
 
-- Financial analyst at KPMG.
+- Entry-level financial adviser at KPMG.
 
 **Data Science Education Experience**
 
-Having only worked with excel and some SPSS in his studies, Umberto
-learned most of the modelling and analysis techniques on the job. The
-managers he worked with so far in his projects used Excel and custom
-KPMG tools, and he hasn't been in touch with data science tools as of
-now.  He thus doesn't know about them or how they could help him yet.
+Umberto's degree gave him an excellent grounding in economic theory,
+but the only quantitative work he did was with very small data sets
+using Excel and a little bit of copy-and-pase SPSS.  The managers he
+worked with so far in his projects used more complex spreadsheets and
+some software packages developed in house; he hasn't yet had much
+exposure to R, Python, SQL, or other stars in the data science
+constellation, and is only vaguely aware of how they could help him.
 However, Umberto is constantly looking for easier and more efficient
 ways of doing his job tasks-at-hand to move up in his demanding
 career.
@@ -47,11 +49,10 @@ Umberto doesn't know DataCamp.
 
 **Career Goal**
 
-Having a not-so-common education background, Umberto is set on
-learning as much as possible working in consultancy for many different
-clients. He loves the on the job trainings and wants to build
-knowledge so he can grow into a project lead role. In the future, he
-sees himself as lead analyst for a food import/export company.
+Aware that his background hasn't given him the samel quantitative
+skills as many of his peers, Umberto is set on learning as much as
+possible as quickly as he can. He loves the on the job trainings and
+wants to build knowledge so he can grow into a project lead role.
 
 > Building analytical reasonings and spreadsheet models from scratch
 > is what I like and spend most of my time at work doing.
@@ -86,7 +87,7 @@ scientist on her team.
 
 **Data Science Education Experience**
 
-SIndhu came out of university with expert-level knowledge of
+Sindhu came out of university with expert-level knowledge of
 immunology, but only knows basic statistical concepts and
 techniques. However, needing to visualise a lot of her findings,
 Sindhu quickly found that nor Excel and JMP - the tools used in her
@@ -237,12 +238,12 @@ pleasantly surprised to find how much she enjoys programming.
 
 **Previous Jobs**
 
-- Pricing analyst for power distributor.
+- Pricing analyst for a power distributor.
 - Financial analyst at Bank of America.
 
 **Current Job**
 
-- Head quantitative analyst in small hedge fund.
+- Head quantitative analyst in a small hedge fund.
 
 **Career Goal**
 


### PR DESCRIPTION
1. Create a new persona who is a mathematical/statistical expert.
2. Distinguish clearly from personas for domain expertise and coding knowledge.
3. Reorder from least to most experienced.
4. Change usage examples to match.
5. Make it clearer that instructors can translate these personas as needed, but should only create new ones if absolutely necessary.