### PR TITLE
add point about capitalization

### DIFF
--- a/docs/courses/guidelines/style.md
+++ b/docs/courses/guidelines/style.md
@@ -192,6 +192,7 @@ x <-
 ## Comments
 
 - Start each comment on a new line. The comment should begin with the comment symbol and a single space: `#`.
+- Capitalize the first letter of every comment.
 - If you have multiple sentences in your comment, end each with a period. If you have one sentence, no `.` is required.
 
 ~~~~~


### PR DESCRIPTION
Instructors frequently use lower case for all of their comments. We have always capitalized the first letter of every comment across all our courses, but I don't see this mentioned in a style guide anywhere. This should do until we have a more comprehensive style guide in place for all technologies.