### PR TITLE
Remove img, logo, badge for course mentions as needed.

### DIFF
--- a/docs/courses/assets.md
+++ b/docs/courses/assets.md
@@ -1,12 +1,8 @@
-# Assets: Images & Datasets
+# Assets
 
-A DataCamp course has a badge, and your exercises will typically use datasets, so you can add these assets to your course through our platform or through GitHub.
+A DataCamp course's exercises will typically use datasets, so you can add these assets to your course through our platform or through GitHub. Slides also often use images and these can be uploaded as assets as well.
 
-## Images
-
-When you create a course with the "[Create a DataCamp Course](/interface/create-content-dialog.md)" dialog, DataCamp creates an `img/` folder with a template course shield image called `shield_image.png`. You can replace the course shield image with your own so long as you use the same name and keep the file's size under 1Mb. As soon as you push the changes to GitHub, your course's image will be updated.
-
-## Datasets
+## Images and Datasets
 
 The recommended way of uploading your assets is by using the [Teach editor assets interface](/interface/teach-editor.md#editor-upload-assets).  However, you can also add files directly to the `datasets` folder in the root of your course's repository (and create the folder if it doesn't exist). Every file in the `datasets` folder with a recognized extension will be uploaded whenever you push the changes to GitHub. The build logs in the repository overview will inform that they have been uploaded to DataCamp's S3 servers and provide a link you can use in `requirements.r`, `requirements.sh`, or the `pre_exercise_code` block of your exercises to download the file.
 

--- a/docs/courses/repo-structure.md
+++ b/docs/courses/repo-structure.md
@@ -6,8 +6,6 @@ In general, the repository contains:
 
 ```text
 |- datasets/
-|- img
-|  |- shield_image.png
 |- .gitignore
 |- README.md
 |- chapter1.md
@@ -30,7 +28,6 @@ An overview of what each of this does is:
 | File/Folder            | Description |
 |:-----------------------|:------------|
 | `datasets/*`           | Contains all datasets you may want to use in your course (e.g., CSV files) |
-| `img/shield_image.png` | Logo image for the course |
 | `scripts/*`            | Contains all the narrative for the course's slides and videos |
 | `slides/*`             | Contains the Markdown slides for your course's videos |
 | `.gitignore`           | Specifies files and folders that Git should ignore |


### PR DESCRIPTION
Didn't remove all of the badge mentions since some of them do need to be in there. For example, when discussing how long a title of a course should be.