### PR TITLE
fixed confusion about number of MCE per lesson

### DIFF
--- a/docs/courses/design/README.md
+++ b/docs/courses/design/README.md
@@ -58,8 +58,7 @@ A typical breakdown is:
 Each lesson is comprised of:
 
 - a video lesson with slides, e.g. [sample video lesson](https://campus.datacamp.com/courses/supervised-learning-with-scikit-learn/classification?ex=9) 
-- one multiple choice exercise following the video
-- 2-4 coding exercises
+- 2-4 exercises, of which at least 2 are coding exercises
 
 ## Types of courses
 


### PR DESCRIPTION
Background: almost at the end of Ch2 I had to tell an instructor that courses cannot have more than 5 MCE. Apparently this instructor had seen line edited in this PR in Authoring and thought that one MCE was necessary in each lesson. Now instructor is upset/frustrated because has to convert several exercises into coding ones.