### PR TITLE
get rid of SCT examples

### DIFF
--- a/docs/courses/exercises/console-exercise.md
+++ b/docs/courses/exercises/console-exercise.md
@@ -34,6 +34,6 @@ A `ConsoleExercise` only features a console. Typing a command in the console and
     `@sct`
 
     ```{python}
-    Ex().test_expr_error('[ -d "test" ]')
+
     Ex().success_msg("Great!")
     ```

--- a/docs/courses/exercises/examples/ipynb/python/MultipleChoiceExercise.ipynb
+++ b/docs/courses/exercises/examples/ipynb/python/MultipleChoiceExercise.ipynb
@@ -74,7 +74,7 @@
     "msg2 = \"Incorrect. There is a very popular framework to build database-driven websites (Django), but Python can do much more.\"\n",
     "msg3 = \"Incorrect. Python is a powerful tool to do data analysis, but you can also use it for other ends.\"\n",
     "msg4 = \"Correct! Python is an extremely versatile language.\"\n",
-    "test_mc(4, [msg1, msg2, msg3, msg4])\n"
+    "Ex().has_chosen(4, [msg1, msg2, msg3, msg4])\n"
    ]
   }
  ],

--- a/docs/courses/exercises/examples/md/r/MarkdownExercise.md
+++ b/docs/courses/exercises/examples/md/r/MarkdownExercise.md
@@ -145,14 +145,7 @@ ul {
 `@sct`
 
 ```{r}
-test_error()
-test_rmd_file({
-  test_yaml_header(options = "title",
-                   not_called_msg = "Make sure to define the title on top of the R Markdown document in the editor.",
-                   incorrect_msg = "Set the title of the document to \"Hello R Markdown\". Beware of typos and caps!")
-  test_yaml_header(options = "output.html_document.css",
-                   not_called_msg = "Don't change anything in the title apart from the document title!",
-                   incorrect_msg = "Don't change anything in the title apart from the document title!")
-})
+Ex() %>% check_error()
+# SCT comes here
 success_msg("Nice job! Cool, right? Continue to the next exercise to get introduced to the basics of R Markdown.")
 ```

--- a/docs/courses/exercises/examples/md/r/MultipleChoiceExercise.md
+++ b/docs/courses/exercises/examples/md/r/MultipleChoiceExercise.md
@@ -58,5 +58,5 @@ dice1 + dice2
 msg1 <- "Calling `two_dice()` doesn't throw an error; feel free to try it out in the console. Try again."
 msg2 <- "Assigning the result of a function to a variable does not change anything about the scoping of the variables inside that function. Have another go at it."
 msg3 <- "Great! If you're familiar with other programming languages, you might wonder whether R passes arguments <i>by value</i> or <i>by reference</i>. Find out in the next exercise!"
-test_mc(3, feedback_msgs = c(msg1, msg2, msg3))
+ex() %>% check_mc(3, feedback_msgs = c(msg1, msg2, msg3))
 ```

--- a/docs/courses/exercises/examples/md/r/NormalExercise.md
+++ b/docs/courses/exercises/examples/md/r/NormalExercise.md
@@ -45,6 +45,6 @@ Just add a line of R code that calculates the sum of 6 and 12, just like the exa
 `@sct`
 
 ```{r}
-test_output_contains("18", incorrect_msg = "Make sure to add `6 + 12` on a new line. Do not start the line with a `#`, otherwise your R code is not executed!")
-success_msg("Awesome! See how the console shows the result of the R code you submitted? Now that you're familiar with the interface, let's get down to R business!")
+ex() %>% check_output_expr("6 + 12")
+success_msg("Awesome!")
 ```

--- a/docs/courses/exercises/examples/md/r/RStudioMultipleChoiceExercise.md
+++ b/docs/courses/exercises/examples/md/r/RStudioMultipleChoiceExercise.md
@@ -30,5 +30,5 @@ Remember, you can view interactive output within the viewer tab.
 msg1 <- "Correct!"
 msg2 <- "Incorrect, rewatch the video and see what Garrett says about the viewer pane."
 
-test_mc(1, feedback_msgs = c(msg1, msg2))
+ex() %>% check_mc(1, feedback_msgs = c(msg1, msg2))
 ```

--- a/docs/courses/exercises/examples/md/shell/BulletConsoleExercise.md
+++ b/docs/courses/exercises/examples/md/shell/BulletConsoleExercise.md
@@ -44,7 +44,6 @@ mkdir films;
 `@sct`
 
 ```{python}
-Ex().test_expr_error('ls films', output = "0")
 Ex().success_msg("Great!")
 ```
 
@@ -80,8 +79,6 @@ ls;
 `@sct`
 
 ```{python}
-# MC-NOTE: if these exercises aren't stateful, won't have anything in cwd, so SCT will fail
-Ex().test_output_contains('films', "Does the output of your command include the `films`?")
 Ex().success_msg("Great!")
 ```
 
@@ -117,6 +114,5 @@ ls -la;
 `@sct`
 
 ```{python}
-Ex().test_expr_output('ls -la')
 Ex().success_msg("Great!")
 ```

--- a/docs/courses/exercises/examples/md/shell/ConsoleExercise.md
+++ b/docs/courses/exercises/examples/md/shell/ConsoleExercise.md
@@ -22,7 +22,5 @@ mkdir test
 `@sct`
 
 ```{python}
-# see https://stackoverflow.com/questions/59838/check-if-a-directory-exists-in-a-shell-script
-Ex().test_expr_error('[ -d "test" ]')
 Ex().success_msg("Great!")
 ```

--- a/docs/courses/exercises/examples/md/shell/TabConsoleExercise.md
+++ b/docs/courses/exercises/examples/md/shell/TabConsoleExercise.md
@@ -44,7 +44,6 @@ mkdir films;
 `@sct`
 
 ```{python}
-Ex().test_expr_error('ls films', output = "0")
 Ex().success_msg("Great!")
 ```
 
@@ -80,8 +79,6 @@ ls;
 `@sct`
 
 ```{python}
-# MC-NOTE: if these exercises aren't stateful, won't have anything in cwd, so SCT will fail
-Ex().test_output_contains('films', "Does the output of your command include the `films`?")
 Ex().success_msg("Great!")
 ```
 
@@ -117,6 +114,5 @@ ls -la;
 `@sct`
 
 ```{python}
-Ex().test_expr_output('ls -la')
 Ex().success_msg("Great!")
 ```

--- a/docs/courses/exercises/examples/md/sql/BulletExercise.md
+++ b/docs/courses/exercises/examples/md/sql/BulletExercise.md
@@ -61,21 +61,7 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    distinct = sel.check_field('pref').has_equal_ast("Don't forget to use the `DISTINCT` keyword!")
-
-    country = test_column('country', msg='Did you select the `country` column?')
-
-    from_clause = sel.check_field('from_clause').has_equal_ast('Is your `FROM` clause correct?')
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        distinct,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```
 
     ***
@@ -106,22 +92,7 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    distinct = sel.check_field('pref').has_equal_ast("Don't forget to use the `DISTINCT` keyword!")
-
-    certification = test_column('certification', msg='Did you select the `certification` column?')
-
-    from_clause = sel.check_field('from_clause').has_equal_ast('Is your `FROM` clause correct?')
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        certification,
-        distinct,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```
 
     ***
@@ -152,20 +123,5 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    distinct = sel.check_field('pref').has_equal_ast("Don't forget to use the `DISTINCT` keyword!")
-
-    role = test_column('role', msg='Did you select the `role` column?')
-
-    from_clause = sel.check_field('from_clause').has_equal_ast('Is your `FROM` clause correct?')
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        distinct,
-        role,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```

--- a/docs/courses/exercises/examples/md/sql/MultipleChoiceExercise.md
+++ b/docs/courses/exercises/examples/md/sql/MultipleChoiceExercise.md
@@ -42,6 +42,5 @@ Run the code in the editor and look at the query result tab under the editor!
 ```{python}
 msg1 = 'Nope, look at the query result tab!'
 correct = 'Correct!'
-
-Ex().test_mc(2, [msg1, correct, msg1, msg1])
+Ex().has_chosen(2, [msg1, correct, msg1, msg1])
 ```

--- a/docs/courses/exercises/examples/md/sql/NormalExercise.md
+++ b/docs/courses/exercises/examples/md/sql/NormalExercise.md
@@ -55,7 +55,6 @@ AS result;
 `@sct`
 
 ```{sql}
-Ex().test_student_typed('SELECT|select', msg='You need to add `SELECT` at the start of line 2!')
-Ex().test_has_columns()
-Ex().test_error()
+Ex().has_code('SELECT|select', msg='You need to add `SELECT` at the start of line 2!')
+Ex().success_msg("Well done!")
 ```

--- a/docs/courses/exercises/examples/md/sql/TabExercise.md
+++ b/docs/courses/exercises/examples/md/sql/TabExercise.md
@@ -68,30 +68,7 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    title = test_column('title', msg='Did you select the `title` column?')
-
-    release_year = test_column('release_year', msg='Did you select the `release_year` column?')
-
-    from_clause = sel.check_field('from_clause')
-
-    where_clause = sel.check_field('where_clause')
-
-    where_release_year1 = where_clause.has_equal_ast(sql='release_year >= 1990', start='expression', exact=False, msg='Did you check the `release_year` correctly in your `WHERE` clause?')
-
-    where_release_year2 = where_clause.has_equal_ast(sql='release_year < 2000', start='expression', exact=False, msg='Did you check the `release_year` correctly in your `WHERE` clause?')
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        where_release_year1,
-        where_release_year2,
-        title,
-        release_year,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```
 
     ***
@@ -126,37 +103,7 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    title = test_column('title', msg='Did you select the `title` column?')
-
-    release_year = test_column('release_year', msg='Did you select the `release_year` column?')
-
-    from_clause = sel.check_field('from_clause')
-
-    where_clause = sel.check_field('where_clause')
-
-    where_release_year1 = where_clause.has_equal_ast(sql='release_year >= 1990', start='expression', exact=False, msg='Did you check the `release_year` correctly in your `WHERE` clause?')
-
-    where_release_year2 = where_clause.has_equal_ast(sql='release_year < 2000', start='expression', exact=False, msg='Did you check the `release_year` correctly in your `WHERE` clause?')
-
-    where_language1 = where_clause.has_equal_ast(sql="language = 'French'", start='expression', exact=False, msg='Did you check the `language` correctly in your `WHERE` clause?')
-
-    where_language2 = where_clause.has_equal_ast(sql="language = 'Spanish'", start='expression', exact=False, msg='Did you check the `language` correctly in your `WHERE` clause?')
-
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        where_release_year1,
-        where_release_year2,
-        where_language1,
-        where_language2,
-        title,
-        release_year,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```
 
     ***
@@ -193,37 +140,5 @@
     `@sct`
 
     ```{python}
-    sel = check_node('SelectStmt')
-
-    title = test_column('title', msg='Did you select the `title` column?')
-
-    release_year = test_column('release_year', msg='Did you select the `release_year` column?')
-
-    from_clause = sel.check_field('from_clause')
-
-    where_clause = sel.check_field('where_clause')
-
-    where_release_year1 = where_clause.has_equal_ast(sql='release_year >= 1990', start='expression', exact=False, msg='Did you check the `release_year` correctly?')
-
-    where_release_year2 = where_clause.has_equal_ast(sql='release_year < 2000', start='expression', exact=False, msg='Did you check the `release_year` correctly in your `WHERE` clause?')
-
-    where_language1 = where_clause.has_equal_ast(sql="language = 'French'", start='expression', exact=False, msg='Did you check the `language` correctly in your `WHERE` clause?')
-
-    where_language2 = where_clause.has_equal_ast(sql="language = 'Spanish'", start='expression', exact=False, msg='Did you check the `language` correctly in your `WHERE` clause?')
-
-    where_gross = where_clause.has_equal_ast(sql='gross > 2000000', start='expression', exact=False, msg='Did you check the `gross` correctly in your `WHERE` clause?')
-
-    Ex().test_correct(check_result(), [
-        from_clause,
-        where_release_year1,
-        where_release_year2,
-        where_language1,
-        where_language2,
-        where_gross,
-        title,
-        release_year,
-        test_has_columns(),
-        test_ncols(),
-        test_error()
-    ])
+    # SCT comes here, see sqlwhat.readthedocs.io
     ```

--- a/docs/courses/exercises/examples/md/sql/TabExerciseWithMultipleChoice.md
+++ b/docs/courses/exercises/examples/md/sql/TabExerciseWithMultipleChoice.md
@@ -78,7 +78,7 @@ msg1 = "Option 1 is wrong.."
 msg2 = "Option 2 is correct, great!"
 msg3 = "Option 3 is wrong.."
 msg4 = "Option 4 is wrong.."
-Ex().test_mc(2,[msg1,msg2,msg3,msg4])
+Ex().has_chosen(2,[msg1,msg2,msg3,msg4])
 ```
 
 ***

--- a/docs/courses/exercises/multiple-choice-exercises/README.md
+++ b/docs/courses/exercises/multiple-choice-exercises/README.md
@@ -48,7 +48,8 @@ This is an example taken from DataCamp's [Introduction to Python for Data Scienc
     msg2 = "Incorrect. There is a very popular framework to build database-driven websites (Django), but Python can do much more."
     msg3 = "Incorrect. Python is a powerful tool to do data analysis, but you can also use it for other ends."
     msg4 = "Correct! Python is an extremely versatile language."
-    test_mc(4, [msg1, msg2, msg3, msg4])
+    Ex().has_chosen(4, [msg1, msg2, msg3, msg4])
+    ```
 
 #### Context
 
@@ -92,13 +93,12 @@ A `MultipleChoiceExercise` starts with `## Title`, followed by a `metadata` bloc
     msg2 = "Incorrect. There is a very popular framework to build database-driven websites (Django), but Python can do much more."
     msg3 = "Incorrect. Python is a powerful tool to do data analysis, but you can also use it for other ends."
     msg4 = "Correct! Python is an extremely versatile language."
-    test_mc(4, [msg1, msg2, msg3, msg4])
+    Ex().has_chosen(4, [msg1, msg2, msg3, msg4])
     ```
     
-The `test_mc()` function is used to provide tailored feedback in a `MultipleChoiceExercise`. It varies slightly  depending on the technology. The same test for an R course would be `test_mc(4, feedback_msgs = c(msg1, msg2, msg3, msg4))`, and for a Shell course, would be `Ex() >> test_mc(4, [msg1, msg2, msg3, msg4])`.
+The `Ex().has_chosen()` function is used to provide tailored feedback in a `MultipleChoiceExercise`. It varies slightly  depending on the technology. The same test for an R course would be `ex() %>% check_mc(4, feedback_msgs = c(msg1, msg2, msg3, msg4))`.
     
-Regardless of technology, the `test_mc()` function takes in two required arguments. The first encodes the correct response (option 4 in the above example), while the second required argument is a list of strings (or _vector_ of strings, in R exercises) of length equal to the number of possible options. Each string corresponds to the feedback message that learners would see if they were to select that option. It is encouraged to write informative feedback messages, as these provide an opportunity for you to correct any mistaken mental models learners may have and guide them towards the solution.
-    
+Regardless of technology, the function takes in two required arguments. The first encodes the correct response (option 4 in the above example), while the second required argument is a list of strings (or _vector_ of strings, in R exercises) of length equal to the number of possible options. Each string corresponds to the feedback message that learners would see if they were to select that option. It is encouraged to write informative feedback messages, as these provide an opportunity for you to correct any mistaken mental models learners may have and guide them towards the solution.
 
 See also:
 - [Exercises](/courses/exercises/README.md#exercise-blocks)  
@@ -108,7 +108,7 @@ See also:
 
 ![Pure Multiple Choice Exercise](/images/PlainMultipleChoiceExerciseR.png)
 
-A `PureMultipleChoiceExercise` is a `MultipleChoiceExercise` question that does not display a console, i.e., does not have any coding.  Instead of using `test_mc` inside an `sct` block, you use a `feedback` block.
+A `PureMultipleChoiceExercise` is a `MultipleChoiceExercise` question that does not display a console, i.e., does not have any coding.  Instead of using the R/Python-coded SCT inside an `sct` block, you use a `feedback` block.
 
 ### Example
 

--- a/docs/courses/exercises/normal-exercises/README.md
+++ b/docs/courses/exercises/normal-exercises/README.md
@@ -58,10 +58,8 @@ This chapter contains one `NormalExercise` for R.  Each block is described in de
 
     `@sct`
     ```{r}
-    test_error()
-    test_object("x",
-                undefined_msg = "Make sure to define `x`!",
-                incorrect_msg = "Have you correctly assigned 5 to `x`!")
+    ex() %>% check_error()
+    ex() %>% check_object("x") %>% check_equal()
     success_msg("Awesome! It's considered good style to write spaces either side of the assignment arrow.")
     ```
 
@@ -115,10 +113,8 @@ A `NormalExercise` starts with `## Title`, followed by a `metadata` block and a 
 
     `@sct`
     ```{r}
-    test_error()
-    test_object("x",
-                undefined_msg = "Make sure to define `x`!",
-                incorrect_msg = "Have you correctly assigned 5 to `x`!")
+    ex() %>% check_error()
+    ex() %>% check_object("x") %>% check_equal()
     success_msg("Awesome! It's considered good style to write spaces either side of the assignment arrow.")
     ```
 

--- a/docs/courses/exercises/tab-exercise.md
+++ b/docs/courses/exercises/tab-exercise.md
@@ -226,19 +226,20 @@ Following is an example on how to author this type of exercise:
     ```{r}
     #' @step
     # Sct for first Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for second Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for third Normal Exercise
-    test_correct(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for fourth Normal Exercise
-    test_function(...)
+    ex() %>% check_function(...)
+
     success_msg("Good job!")
     ```
 
@@ -353,19 +354,20 @@ SCT for each of the Normal Exercises being created, where the each `NormalExerci
     ```{r}
     #' @step
     # Sct for first Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for second Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for third Normal Exercise
-    test_correct(...)
+    ex() %>% check_object(...)
 
     #' @step
     # Sct for fourth Normal Exercise
-    test_function(...)
+    ex() %>% check_function(...)
+
     success_msg("Good job!")
     ```
 
@@ -375,24 +377,26 @@ In this example first `NormalExercise` SCT would be:
 
     ```{r}
     # Sct for first Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
     ```
+
 while last `NormalExercise` SCT would be:
 
     `@sct`
 
     ```{r}
     # Sct for first Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     # Sct for second Normal Exercise
-    test_object(...)
+    ex() %>% check_object(...)
 
     # Sct for third Normal Exercise
-    test_correct(...)
+    ex() %>% check_object(...)
 
     # Sct for fourth Normal Exercise
-    test_function(...)
+    ex() %>% check_function(...)
+
     success_msg("Good job!")
     ```
 

--- a/docs/courses/exercises/technical-details/sct.md
+++ b/docs/courses/exercises/technical-details/sct.md
@@ -93,9 +93,9 @@ A good SCT allows for different ways of solving the problem but gives targeted a
   Verify the output of the student rather than the code that generated that printout.
   Verify the result of calling a function rather than the arguments used to call that function.
 
-- _Use `test_correct()` whenever it makes sense._
+- _Use `check_correct()` whenever it makes sense._
 
-  The seemingly opposite requirements of robustness to different solutions vs. targeted feedback can be satisfied by using `test_correct()`.
+  The seemingly opposite requirements of robustness to different solutions vs. targeted feedback can be satisfied by using `check_correct()`.
   This function takes two sets of tests: 'checking' tests, and 'diagnosing' tests.
   Checking tests verify the end result, while diagnosting tests dive deeper to look at the mistakes a student made.
   If the checking tests pass, the typically more restrictive diagnosing tests are not executed.


### PR DESCRIPTION
SCT documentation and how to write SCTs should be in the package-specific docs as much as possible. We don't want to duplicate the SCTs and explanations here. It's bad for maintainability.